### PR TITLE
feat(infra, chat, conversation_tabs): implement real-time presence, last seen tracking, and optimistic messaging

### DIFF
--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -2067,6 +2067,26 @@ files = [
 ]
 
 [[package]]
+name = "redis"
+version = "7.3.0"
+description = "Python client for Redis database and key-value store"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "redis-7.3.0-py3-none-any.whl", hash = "sha256:9d4fcb002a12a5e3c3fbe005d59c48a2cc231f87fbb2f6b70c2d89bb64fec364"},
+    {file = "redis-7.3.0.tar.gz", hash = "sha256:4d1b768aafcf41b01022410b3cc4f15a07d9b3d6fe0c66fc967da2c88e551034"},
+]
+
+[package.extras]
+circuit-breaker = ["pybreaker (>=1.4.0)"]
+hiredis = ["hiredis (>=3.2.0)"]
+jwt = ["pyjwt (>=2.9.0)"]
+ocsp = ["cryptography (>=36.0.1)", "pyopenssl (>=20.0.1)", "requests (>=2.31.0)"]
+otel = ["opentelemetry-api (>=1.39.1)", "opentelemetry-exporter-otlp-proto-http (>=1.39.1)", "opentelemetry-sdk (>=1.39.1)"]
+xxhash = ["xxhash (>=3.6.0,<3.7.0)"]
+
+[[package]]
 name = "rich"
 version = "14.2.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
@@ -3122,4 +3142,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "8fed32e467b632c0d6caf4f021e11ff48aa65b2dbdefcf37c347a2f7ee2e0072"
+content-hash = "d28d74152adff6e9d38c11c660015e5ce24d7ed7d32314f033a507cd79e73226"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "psycopg2 (>=2.9.11,<3.0.0)",
     "python-jose (>=3.5.0,<4.0.0)",
     "aioboto3 (>=15.5.0,<16.0.0)",
+    "redis (>=7.3.0,<8.0.0)",
 ]
 
 [tool.poetry]

--- a/backend/src/auth/models.py
+++ b/backend/src/auth/models.py
@@ -41,6 +41,10 @@ class UserProfile(Base):
         DateTime(timezone=True), server_default=func.now()
     )
 
+    last_online: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     is_email_verified: Mapped[bool] = mapped_column(
         Boolean, server_default="false", nullable=False, index=True
     )

--- a/backend/src/auth/schemas.py
+++ b/backend/src/auth/schemas.py
@@ -46,5 +46,6 @@ class BaseFriendResponse(UserMinimal):
     conversation_id: Optional[UUID] = None
 
 
-class UserMinimalWithFriendshipStatus(UserMinimal):
+class UserMinimalWithStatus(UserMinimal):
     friendship_status: str
+    is_online: bool

--- a/backend/src/auth/schemas.py
+++ b/backend/src/auth/schemas.py
@@ -47,6 +47,11 @@ class BaseFriendResponse(UserMinimal):
 
 
 class UserMinimalWithStatus(UserMinimal):
-    friendship_status: str
+    friendship_status: (
+        str | None
+    )  # Only for testing, this should not be None, remove | None later
     is_online: bool
-    last_online: datetime
+    last_online: datetime | None
+
+    last_read_message_id: UUID | None
+    last_read_message_at: datetime | None

--- a/backend/src/auth/schemas.py
+++ b/backend/src/auth/schemas.py
@@ -49,3 +49,4 @@ class BaseFriendResponse(UserMinimal):
 class UserMinimalWithStatus(UserMinimal):
     friendship_status: str
     is_online: bool
+    last_online: datetime

--- a/backend/src/auth/services.py
+++ b/backend/src/auth/services.py
@@ -95,12 +95,13 @@ class AuthService:
                 update(UserProfile)
                 .where(UserProfile.user_id == user_id)
                 .values(last_online=func.now())
+                .returning(UserProfile.last_online)
             )
 
-            await db.execute(query)
+            result = await db.execute(query)
             await db.commit()
+            return result.scalar_one()
 
-            return {"message": "Last online updated successfully."}
         except Exception:
             traceback.print_exc()
 

--- a/backend/src/auth/services.py
+++ b/backend/src/auth/services.py
@@ -1,7 +1,7 @@
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from sqlalchemy import select, update
+from sqlalchemy import select, update, func
 
 from .models import UserProfile
 from .schemas import UserUpdate
@@ -84,6 +84,23 @@ class AuthService:
             await db.commit()
 
             return {"message": "Profile image URL updated successfully"}
+        except Exception:
+            traceback.print_exc()
+
+    @staticmethod
+    async def update_last_online(db: AsyncSession, user_id: UUID):
+
+        try:
+            query = (
+                update(UserProfile)
+                .where(UserProfile.user_id == user_id)
+                .values(last_online=func.now())
+            )
+
+            await db.execute(query)
+            await db.commit()
+
+            return {"message": "Last online updated successfully."}
         except Exception:
             traceback.print_exc()
 

--- a/backend/src/core/__init__.py
+++ b/backend/src/core/__init__.py
@@ -3,3 +3,4 @@ from .config import settings  # noqa: F401
 from .database import get_db, AsyncSessionLocal  # noqa: F401
 from .schemas import BaseSchema  # noqa: F401
 from .storage import get_s3_client  # noqa: F401
+from .redis import get_redis  # noqa: F401

--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -12,6 +12,8 @@ class Settings(BaseSettings):
     SUPABASE_S3_SECRET_KEY: str
     SUPABASE_S3_BUCKET_NAME: str
 
+    REDIS_URL: str
+
     model_config = SettingsConfigDict(
         env_file="../.env", env_file_encoding="utf-8", extra="ignore"
     )

--- a/backend/src/core/redis.py
+++ b/backend/src/core/redis.py
@@ -1,0 +1,23 @@
+import redis.asyncio as redis
+from typing import AsyncGenerator
+from .config import settings
+
+# Async Redis client
+redis_client = redis.from_url(
+    settings.REDIS_URL,
+    encoding="utf-8",
+    decode_responses=True,
+)
+
+
+async def get_redis() -> AsyncGenerator[redis.Redis, None]:
+    try:
+        yield redis_client
+    except Exception:
+        raise
+    finally:
+        pass
+
+
+async def close_redis():
+    await redis_client.aclose()

--- a/backend/src/core/websocket.py
+++ b/backend/src/core/websocket.py
@@ -7,6 +7,12 @@ class ConnectionManager:
     def __init__(self):
         self.user_connections: dict[UUID, list[WebSocket]] = {}
 
+    def get_current_connections_for_a_user(self, user_id: UUID):
+        return self.user_connections.get(user_id, [])
+
+    def get_num_of_current_connections_for_a_user(self, user_id: UUID):
+        return len(self.get_current_connections_for_a_user(user_id))
+
     async def connect(self, websocket: WebSocket, user_id: UUID):
         await websocket.accept()
 

--- a/backend/src/messages/models.py
+++ b/backend/src/messages/models.py
@@ -111,5 +111,9 @@ class ConversationParticipant(Base):
         DateTime(timezone=True), server_default=func.now()
     )
 
+    last_read_message_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True))
+
+    last_read_message_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+
     user = relationship("UserProfile")
     conversation = relationship("Conversation", back_populates="participants")

--- a/backend/src/messages/router.py
+++ b/backend/src/messages/router.py
@@ -390,12 +390,14 @@ async def mark_conversation_as_read(
         if result:
             message_seen_dict = {
                 "conversationId": str(conversation_id),
-                "lastReadMessageId": str(result.last_read_message_id),
+                "lastReadMessageId": str(result["last_read_message_id"]),
                 "lastReadMessageAt": (
-                    result.last_read_message_at.isoformat()
-                    if result.last_read_message_at
+                    result["last_read_message_at"].isoformat()
+                    if result["last_read_message_at"]
                     else None
                 ),
+                "hasSeenLatestMessage": True,
+                "latestMessageSenderId": str(result["latest_message_sender_id"]),
             }
 
             event_data = {"type": "MESSAGE_SEEN", "data": message_seen_dict}

--- a/backend/src/messages/router.py
+++ b/backend/src/messages/router.py
@@ -20,6 +20,7 @@ from .schemas import (
     ConversationIdWithType,
     ConversationIdWithTheme,
     ConversationTheme,
+    ConversationId,
 )
 
 from src.auth.schemas import UserMinimalWithStatus, TargetUserId
@@ -350,6 +351,56 @@ async def update_conversation_theme(
                     await manager.send_to_user(conversation_participant, event_data)
 
         return theme_details
+
+    except Exception:
+        traceback.print_exc()
+        raise HTTPException(status_code=500, detail="Internal Server Error")
+
+
+@router.post("/mark-as-read")
+async def mark_conversation_as_read(
+    payload: ConversationId,
+    user_id: Annotated[UUID, Depends(get_current_user_id)],
+    db: AsyncSession = Depends(get_db),
+):
+
+    try:
+        conversation_id = payload.conversation_id
+
+        result = await MessagesService.mark_conversation_as_read(
+            db, payload.conversation_id, user_id
+        )
+
+        conversation_participants = []
+
+        conversation_participants = (
+            await MessagesService.get_other_participants_details_in_conversation(
+                db, conversation_id, user_id
+            )
+            or []
+        )
+
+        other_participant = next(
+            (p for p in conversation_participants if p["user_id"] != user_id), None
+        )
+
+        if other_participant is None:
+            raise HTTPException(status_code=404, detail="User not found")
+
+        if result:
+            message_seen_dict = {
+                "conversationId": str(conversation_id),
+                "lastReadMessageId": str(result.last_read_message_id),
+                "lastReadMessageAt": (
+                    result.last_read_message_at.isoformat()
+                    if result.last_read_message_at
+                    else None
+                ),
+            }
+
+            event_data = {"type": "MESSAGE_SEEN", "data": message_seen_dict}
+
+            await manager.send_to_user(UUID(str(other_participant.user_id)), event_data)
 
     except Exception:
         traceback.print_exc()

--- a/backend/src/messages/router.py
+++ b/backend/src/messages/router.py
@@ -155,7 +155,12 @@ async def send_message(
         )
 
         if user_details:
-            msg_dict.update({"username": user_details.username})
+            msg_dict.update(
+                {
+                    "username": user_details.username,
+                    "tempMessageId": str(payload.temp_message_id),
+                }
+            )
 
             event_data = {"type": "NEW_MESSAGE", "data": msg_dict}
 

--- a/backend/src/messages/router.py
+++ b/backend/src/messages/router.py
@@ -49,6 +49,7 @@ async def websocket_endpoint(
     websocket: WebSocket,
     user_id: Annotated[UUID, Depends(get_current_user_id)],
     redis: Redis = Depends(get_redis),
+    db: AsyncSession = Depends(get_db),
 ):
 
     await manager.connect(websocket, user_id)
@@ -58,13 +59,30 @@ async def websocket_endpoint(
 
     try:
         while True:
-            await websocket.receive_text()
+            data = await websocket.receive_json()
+
+            if data["type"] == "PING":
+                await redis.set(f"online:{user_id}", "1", ex=60)
+                await websocket.send_json({"type": "PONG"})
+
     except InvalidConversationID:
         traceback.print_exc()
         await websocket.close(code=3001)
-    except (WebSocketDisconnect, Exception):
+    except WebSocketDisconnect:
         traceback.print_exc()
         manager.disconnect(websocket, user_id)
+
+        remaining_connections = manager.get_num_of_current_connections_for_a_user(
+            user_id
+        )
+
+        if remaining_connections == 0:
+            await redis.delete(f"online:{user_id}")
+
+            await AuthService.update_last_online(db, user_id)
+
+    except Exception:
+        traceback.print_exc()
 
 
 @router.post("/send", response_model=MessageRead)

--- a/backend/src/messages/router.py
+++ b/backend/src/messages/router.py
@@ -6,7 +6,7 @@ from fastapi import (
     HTTPException,
     Query,
 )
-from src.core import manager, get_db
+from src.core import manager, get_db, get_redis
 
 from src.auth.dependencies import get_current_user_id
 
@@ -22,7 +22,7 @@ from .schemas import (
     ConversationTheme,
 )
 
-from src.auth.schemas import UserMinimalWithFriendshipStatus, TargetUserId
+from src.auth.schemas import UserMinimalWithStatus, TargetUserId
 from src.auth.services import AuthService
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -32,6 +32,8 @@ import uuid
 
 import traceback
 from typing import Annotated
+
+from redis import Redis
 
 from .exceptions import InvalidConversationID
 
@@ -46,9 +48,14 @@ router = APIRouter(
 async def websocket_endpoint(
     websocket: WebSocket,
     user_id: Annotated[UUID, Depends(get_current_user_id)],
+    redis: Redis = Depends(get_redis),
 ):
 
     await manager.connect(websocket, user_id)
+
+    # Only store "1" in redis, it is just a placeholder to know if user is online
+    await redis.set(f"online:{user_id}", "1", ex=60)
+
     try:
         while True:
             await websocket.receive_text()
@@ -139,12 +146,13 @@ async def get_conversation_list(
 
 @router.get(
     "/{conversation_id}/other-participant",
-    response_model=UserMinimalWithFriendshipStatus,
+    response_model=UserMinimalWithStatus,
 )
 async def get_other_conversation_participant(
     user_id: Annotated[UUID, Depends(get_current_user_id)],
     conversation_id: UUID,
     db: AsyncSession = Depends(get_db),
+    redis: Redis = Depends(get_redis),
 ):
 
     try:
@@ -169,7 +177,17 @@ async def get_other_conversation_participant(
         if other_participant is None:
             raise HTTPException(status_code=404, detail="User not found")
 
-        return other_participant
+        other_participant_dict = dict(other_participant)
+
+        is_online = (
+            True
+            if await redis.exists(f"online:{other_participant_dict["user_id"]}") == 1
+            else False
+        )
+
+        other_participant_dict.update({"is_online": is_online})
+
+        return other_participant_dict
 
     except Exception:
         traceback.print_exc()

--- a/backend/src/messages/router.py
+++ b/backend/src/messages/router.py
@@ -33,9 +33,10 @@ import uuid
 import traceback
 from typing import Annotated
 
-from redis import Redis
+from redis.asyncio import Redis
 
 from .exceptions import InvalidConversationID
+
 
 router = APIRouter(
     prefix="/api/messages",
@@ -54,15 +55,31 @@ async def websocket_endpoint(
 
     await manager.connect(websocket, user_id)
 
+    # online:{user_id} is for general online state, while online_users is for group operations
+
     # Only store "1" in redis, it is just a placeholder to know if user is online
     await redis.set(f"online:{user_id}", "1", ex=60)
 
+    await redis.sadd("online_users", str(user_id))  # type: ignore
+
     try:
+        online_direct_message_participants = await redis.sinter(f"user:direct_message:{user_id}", "online_users")  # type: ignore
+
+        for online_direct_message_participant in online_direct_message_participants:
+            online_status_dict = {"isOnline": True}
+
+            event_data = {"type": "USER_ONLINE", "data": online_status_dict}
+
+            await manager.send_to_user(
+                UUID(online_direct_message_participant), event_data
+            )
+
         while True:
             data = await websocket.receive_json()
 
             if data["type"] == "PING":
                 await redis.set(f"online:{user_id}", "1", ex=60)
+                await redis.sadd("online_users", str(user_id))  # type: ignore
                 await websocket.send_json({"type": "PONG"})
 
     except InvalidConversationID:
@@ -77,9 +94,24 @@ async def websocket_endpoint(
         )
 
         if remaining_connections == 0:
-            await redis.delete(f"online:{user_id}")
+            online_direct_message_participants = await redis.sinter(f"user:direct_message:{user_id}", "online_users")  # type: ignore
 
-            await AuthService.update_last_online(db, user_id)
+            await redis.delete(f"online:{user_id}")
+            await redis.srem("online_users", str(user_id))  # type: ignore
+
+            last_online = await AuthService.update_last_online(db, user_id)
+
+            for online_direct_message_participant in online_direct_message_participants:
+                offline_status_dict = {
+                    "isOnline": False,
+                    "lastOnline": last_online.isoformat() if last_online else None,
+                }
+
+                event_data = {"type": "USER_OFFLINE", "data": offline_status_dict}
+
+                await manager.send_to_user(
+                    UUID(online_direct_message_participant), event_data
+                )
 
     except Exception:
         traceback.print_exc()
@@ -202,6 +234,9 @@ async def get_other_conversation_participant(
             if await redis.exists(f"online:{other_participant_dict["user_id"]}") == 1
             else False
         )
+
+        await redis.sadd(f"user:direct_message:{user_id}", str(other_participant_dict["user_id"]))  # type: ignore
+        await redis.expire(f"user:direct_message:{user_id}", 3600)
 
         other_participant_dict.update({"is_online": is_online})
 

--- a/backend/src/messages/schemas.py
+++ b/backend/src/messages/schemas.py
@@ -37,6 +37,7 @@ class ConversationSnippet(ConversationId):
     latest_message: Optional[str] = None
     latest_message_time: Optional[datetime] = None
     has_seen_latest_message: bool = False
+    latest_message_sender_id: UUID
 
 
 class ConversationList(BaseSchema):

--- a/backend/src/messages/schemas.py
+++ b/backend/src/messages/schemas.py
@@ -36,6 +36,7 @@ class ConversationSnippet(ConversationId):
     other_user_avatar: Optional[str] = None
     latest_message: Optional[str] = None
     latest_message_time: Optional[datetime] = None
+    has_seen_latest_message: bool = False
 
 
 class ConversationList(BaseSchema):

--- a/backend/src/messages/schemas.py
+++ b/backend/src/messages/schemas.py
@@ -16,6 +16,7 @@ class ConversationId(BaseSchema):
 
 class MessageCreate(ConversationId):
     content: str
+    temp_message_id: UUID
 
 
 class MessageRead(ConversationId):

--- a/backend/src/messages/services.py
+++ b/backend/src/messages/services.py
@@ -11,7 +11,7 @@ from src.friends.models import Friendship
 
 from uuid import UUID
 
-from typing import Optional
+from typing import Optional, Any
 
 import traceback
 
@@ -175,6 +175,9 @@ class MessagesService:
                 latest_message_id = (
                     latest_message_obj.message_id if latest_message_obj else None
                 )
+                latest_message_sender_id = (
+                    latest_message_obj.sender_id if latest_message_obj else None
+                )
                 latest_message = (
                     latest_message_obj.content if latest_message_obj else None
                 )
@@ -195,6 +198,7 @@ class MessagesService:
                             == latest_message_id
                             else False
                         ),
+                        "latest_message_sender_id": latest_message_sender_id,
                     }
                 )
 
@@ -336,7 +340,7 @@ class MessagesService:
     @staticmethod
     async def mark_conversation_as_read(
         db: AsyncSession, conversation_id: UUID, user_id: UUID
-    ):
+    ) -> dict[str, Any] | None:
 
         latest_message_id_subquery = (
             select(Message.message_id)
@@ -371,4 +375,21 @@ class MessagesService:
 
         result = await db.execute(stmt)
         await db.commit()
-        return result.mappings().fetchone()
+        row = result.fetchone()
+
+        if row is None:
+            return None
+
+        # Get sender of the last read message
+        sender_result = await db.execute(
+            select(Message.sender_id).where(
+                Message.message_id == row.last_read_message_id
+            )
+        )
+        sender_id = sender_result.scalar_one_or_none()
+
+        return {
+            "last_read_message_id": row.last_read_message_id,
+            "last_read_message_at": row.last_read_message_at,
+            "latest_message_sender_id": sender_id,
+        }

--- a/backend/src/messages/services.py
+++ b/backend/src/messages/services.py
@@ -73,6 +73,7 @@ class MessagesService:
                     ConversationParticipant.user_id,
                     UserProfile.username,
                     UserProfile.profile_image_url,
+                    UserProfile.last_online,
                     Friendship.status.label("friendship_status"),
                 )
                 .join(

--- a/backend/src/messages/services.py
+++ b/backend/src/messages/services.py
@@ -25,10 +25,15 @@ class MessagesService:
     ):
 
         try:
-            db_message = Message(
-                **message_data.model_dump(),
-                sender_id=sender_id,
+            message_data_dict = MessageCreate.model_validate(message_data).model_dump(
+                mode="python"
             )
+
+            del message_data_dict["temp_message_id"]
+
+            message_data_dict.update({"sender_id": sender_id})
+
+            db_message = Message(**message_data_dict)
 
             db.add(db_message)
             await db.commit()

--- a/backend/src/messages/services.py
+++ b/backend/src/messages/services.py
@@ -1,5 +1,5 @@
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, and_, func
+from sqlalchemy import select, and_, func, update, or_
 from sqlalchemy.orm import selectinload
 
 from .schemas import MessageCreate
@@ -74,6 +74,8 @@ class MessagesService:
                     UserProfile.username,
                     UserProfile.profile_image_url,
                     UserProfile.last_online,
+                    ConversationParticipant.last_read_message_id,
+                    ConversationParticipant.last_read_message_at,
                     Friendship.status.label("friendship_status"),
                 )
                 .join(
@@ -315,3 +317,43 @@ class MessagesService:
         await db.commit()
 
         return None
+
+    @staticmethod
+    async def mark_conversation_as_read(
+        db: AsyncSession, conversation_id: UUID, user_id: UUID
+    ):
+
+        latest_message_id_subquery = (
+            select(Message.message_id)
+            .where(Message.conversation_id == conversation_id)
+            .order_by(Message.created_at.desc())
+            .limit(1)
+            .scalar_subquery()
+        )
+
+        stmt = (
+            update(ConversationParticipant)
+            .where(
+                ConversationParticipant.conversation_id == conversation_id,
+                ConversationParticipant.user_id == user_id,
+                or_(
+                    ConversationParticipant.last_read_message_id.is_(
+                        None
+                    ),  # ← NULL case
+                    ConversationParticipant.last_read_message_id
+                    != latest_message_id_subquery,
+                ),
+            )
+            .values(
+                last_read_message_id=latest_message_id_subquery,
+                last_read_message_at=func.now(),
+            )
+            .returning(
+                ConversationParticipant.last_read_message_id,
+                ConversationParticipant.last_read_message_at,
+            )
+        )
+
+        result = await db.execute(stmt)
+        await db.commit()
+        return result.mappings().fetchone()

--- a/backend/src/messages/services.py
+++ b/backend/src/messages/services.py
@@ -154,9 +154,15 @@ class MessagesService:
             formatted_conversations = []
             for conv in conversations:
                 # Find the other person
-                other_person: Optional[UserProfile] = next(
-                    (p.user for p in conv.participants if p.user_id != user_id), None
+
+                other_person_as_participant: Optional[ConversationParticipant] = next(
+                    (p for p in conv.participants if p.user_id != user_id), None
                 )
+
+                if not other_person_as_participant:
+                    continue
+
+                other_person: Optional[UserProfile] = other_person_as_participant.user
 
                 full_name = getattr(other_person, "full_name", "Deleted User")
                 profile_image_url = getattr(
@@ -165,6 +171,9 @@ class MessagesService:
 
                 latest_message_obj = max(
                     conv.messages, key=lambda m: m.created_at, default=None
+                )
+                latest_message_id = (
+                    latest_message_obj.message_id if latest_message_obj else None
                 )
                 latest_message = (
                     latest_message_obj.content if latest_message_obj else None
@@ -180,6 +189,12 @@ class MessagesService:
                         "other_user_avatar": profile_image_url,
                         "latest_message": latest_message,
                         "latest_message_time": latest_message_time,
+                        "has_seen_latest_message": (
+                            True
+                            if other_person_as_participant.last_read_message_id
+                            == latest_message_id
+                            else False
+                        ),
                     }
                 )
 

--- a/frontend/app/(main)/messages/[conversationId]/page.tsx
+++ b/frontend/app/(main)/messages/[conversationId]/page.tsx
@@ -9,7 +9,11 @@ import { useChatStore } from '@/store/useChatStore';
 import { useEffect, useState, useRef } from 'react';
 import LoadingSpinner from '@/components/loadingSpinner';
 
-import { useGetConversationTheme, useGetOtherParticipantFromConversation } from '@/hooks/useChat';
+import {
+  useGetConversationTheme,
+  useGetOtherParticipantFromConversation,
+  useMarkConversationAsRead,
+} from '@/hooks/useChat';
 import { useGetPastMessagesFromConversation } from '@/hooks/useChat';
 
 export default function SpecificConversationPage() {
@@ -23,6 +27,8 @@ export default function SpecificConversationPage() {
   const { getPastMessages } = useGetPastMessagesFromConversation();
 
   const { getActiveConversationTheme } = useGetConversationTheme();
+
+  const { markAsRead } = useMarkConversationAsRead();
 
   const otherParticipantDetails = useChatStore((state) => state.otherParticipantDetails);
 
@@ -42,6 +48,8 @@ export default function SpecificConversationPage() {
       await getOtherParticipant(conversationId);
       await getActiveConversationTheme(conversationId);
       setIsReady(true);
+
+      await markAsRead(conversationId);
     }
     fetchData();
 

--- a/frontend/app/(main)/messages/[conversationId]/page.tsx
+++ b/frontend/app/(main)/messages/[conversationId]/page.tsx
@@ -53,16 +53,13 @@ export default function SpecificConversationPage() {
     }
     fetchData();
 
-    return () => {
-      fetchedIdRef.current = null;
-    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversationId]);
 
   // Clears store when user navigates away from this page
   useEffect(() => {
     return () => {
-      resetConversation();
+      fetchedIdRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/frontend/components/conversationArea.tsx
+++ b/frontend/components/conversationArea.tsx
@@ -2,26 +2,22 @@
 
 import { Button } from './ui/button';
 
-import { InputGroup, InputGroupTextarea } from '@/components/ui/input-group';
-
 import Image from 'next/image';
 import { Icon } from '@iconify/react';
 import MessageThread from './messageThread';
 
-import { useSendMessage } from '@/hooks/useChat';
 import { useChatStore } from '@/store/useChatStore';
 
 import { useState, useEffect } from 'react';
+import MessageInput from './messageInput';
 
 interface ConversationAreaProps {
   onToggle: (newVal?: boolean) => void; // This is a function prop
 }
 
 export default function ConversationArea({ onToggle }: ConversationAreaProps) {
-  const [newMessage, setNewMessage] = useState<string>('');
   const [formattedLastOnline, setFormattedLastOnline] = useState<string>('');
 
-  const { send } = useSendMessage();
   const otherParticipantDetails = useChatStore((state) => state.otherParticipantDetails);
 
   const otherParticipantFriendshipStatus = useChatStore(
@@ -30,18 +26,6 @@ export default function ConversationArea({ onToggle }: ConversationAreaProps) {
 
   const otherParticipantIsOnline = useChatStore((state) => state.otherParticipantIsOnline);
   const otherParticipantLastOnline = useChatStore((state) => state.otherParticipantLastOnline);
-
-  const addSendingMessage = useChatStore((state) => state.addSendingMessage);
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-
-      if (newMessage.trim() !== '') {
-        sendNewMessage();
-      }
-    }
-  };
 
   useEffect(() => {
     if (otherParticipantFriendshipStatus !== 'accepted') {
@@ -71,20 +55,6 @@ export default function ConversationArea({ onToggle }: ConversationAreaProps) {
       }
     }
     return '1m';
-  };
-
-  const sendNewMessage = () => {
-    const tempMessageId: string = crypto.randomUUID();
-
-    addSendingMessage({
-      tempMessageId,
-      content: newMessage.trim(),
-      createdAt: new Date().toISOString(),
-      status: 'sending',
-    });
-
-    send(newMessage.trim(), tempMessageId);
-    setNewMessage('');
   };
 
   useEffect(() => {
@@ -146,30 +116,10 @@ export default function ConversationArea({ onToggle }: ConversationAreaProps) {
 
       <MessageThread />
 
-      <div className="flex gap-2 px-2 my-2 items-end">
-        <InputGroup className="flex-1 shrink-0">
-          <InputGroupTextarea
-            placeholder={
-              otherParticipantFriendshipStatus !== 'accepted'
-                ? `You aren't friends with ${otherParticipantDetails?.username} anymore. This conversation is read-only.`
-                : 'Type your message...'
-            }
-            value={newMessage}
-            onChange={(e) => setNewMessage(e.target.value)}
-            onKeyDown={handleKeyDown}
-            className="min-h-8.5 max-h-40 overflow-y-auto py-2 px-3"
-            disabled={otherParticipantFriendshipStatus !== 'accepted'}
-          />
-        </InputGroup>
-
-        <Button
-          className="cursor-pointer h-9.5"
-          onClick={() => sendNewMessage()}
-          disabled={newMessage.trim() === '' || otherParticipantFriendshipStatus !== 'accepted'}
-        >
-          Send
-        </Button>
-      </div>
+      <MessageInput
+        otherParticipantFriendshipStatus={otherParticipantFriendshipStatus}
+        otherParticipantDetails={otherParticipantDetails}
+      />
     </div>
   );
 }

--- a/frontend/components/conversationArea.tsx
+++ b/frontend/components/conversationArea.tsx
@@ -29,16 +29,16 @@ export default function ConversationArea({ onToggle }: ConversationAreaProps) {
   );
 
   const otherParticipantIsOnline = useChatStore((state) => state.otherParticipantIsOnline);
-
   const otherParticipantLastOnline = useChatStore((state) => state.otherParticipantLastOnline);
+
+  const addSendingMessage = useChatStore((state) => state.addSendingMessage);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
 
       if (newMessage.trim() !== '') {
-        send(newMessage.trim());
-        setNewMessage('');
+        sendNewMessage();
       }
     }
   };
@@ -73,6 +73,20 @@ export default function ConversationArea({ onToggle }: ConversationAreaProps) {
     return '1m';
   };
 
+  const sendNewMessage = () => {
+    const tempMessageId: string = crypto.randomUUID();
+
+    addSendingMessage({
+      tempMessageId,
+      content: newMessage.trim(),
+      createdAt: new Date().toISOString(),
+      status: 'sending',
+    });
+
+    send(newMessage.trim(), tempMessageId);
+    setNewMessage('');
+  };
+
   useEffect(() => {
     const update = () => {
       let timeStr: string = '';
@@ -83,8 +97,6 @@ export default function ConversationArea({ onToggle }: ConversationAreaProps) {
       setFormattedLastOnline(timeStr || '');
     };
 
-    console.log(otherParticipantLastOnline instanceof Date);
-    console.log(otherParticipantLastOnline);
     update();
 
     const interval = setInterval(update, 60000);
@@ -152,7 +164,7 @@ export default function ConversationArea({ onToggle }: ConversationAreaProps) {
 
         <Button
           className="cursor-pointer h-9.5"
-          onClick={() => (send(newMessage.trim()), setNewMessage(''))}
+          onClick={() => sendNewMessage()}
           disabled={newMessage.trim() === '' || otherParticipantFriendshipStatus !== 'accepted'}
         >
           Send

--- a/frontend/components/conversationArea.tsx
+++ b/frontend/components/conversationArea.tsx
@@ -13,12 +13,15 @@ import { useChatStore } from '@/store/useChatStore';
 
 import { useState, useEffect } from 'react';
 
+import { DateFormatters } from '@/types/chat';
+
 interface ConversationAreaProps {
   onToggle: (newVal?: boolean) => void; // This is a function prop
 }
 
 export default function ConversationArea({ onToggle }: ConversationAreaProps) {
   const [newMessage, setNewMessage] = useState<string>('');
+  const [formattedLastOnline, setFormattedLastOnline] = useState<string>('');
 
   const { send } = useSendMessage();
   const otherParticipantDetails = useChatStore((state) => state.otherParticipantDetails);
@@ -42,6 +45,47 @@ export default function ConversationArea({ onToggle }: ConversationAreaProps) {
       onToggle(false);
     }
   }, [otherParticipantFriendshipStatus, onToggle]);
+
+  const formatRelativeTime = (dateString: string) => {
+    const start = new Date(dateString).getTime();
+    const now = Date.now();
+    const diffInSeconds = Math.floor((now - start) / 1000);
+
+    if (diffInSeconds < 60) return 'just now';
+
+    const units = [
+      { label: 'm', seconds: 60 },
+      { label: 'h', seconds: 3600 },
+      { label: 'd', seconds: 86400 },
+      { label: 'w', seconds: 604800 },
+      { label: 'mo', seconds: 2592000 },
+      { label: 'y', seconds: 31536000 },
+    ];
+
+    for (let i = units.length - 1; i >= 0; i--) {
+      if (diffInSeconds >= units[i].seconds) {
+        return `${Math.floor(diffInSeconds / units[i].seconds)}${units[i].label}`;
+      }
+    }
+    return 'just now';
+  };
+
+  useEffect(() => {
+    const update = () => {
+      let timeStr: string = '';
+
+      if (otherParticipantDetails?.lastOnline && otherParticipantDetails?.lastOnline != undefined) {
+        timeStr = formatRelativeTime(otherParticipantDetails?.lastOnline);
+      }
+      setFormattedLastOnline(timeStr || '');
+    };
+
+    update();
+
+    const interval = setInterval(update, 60000);
+
+    return () => clearInterval(interval);
+  }, [otherParticipantDetails?.lastOnline]);
 
   return (
     <div className="flex-3 flex flex-col justify-start gap-2 bg-white dark:bg-stone-900 rounded-xl">
@@ -70,7 +114,9 @@ export default function ConversationArea({ onToggle }: ConversationAreaProps) {
               </div>
             ) : (
               <div className="flex gap-1 items-center">
-                <p className="">Not online</p>
+                <p className="">
+                  Last active {formatRelativeTime('2025-02-21T10:33:33.266919Z')} ago
+                </p>
               </div>
             )}
           </div>

--- a/frontend/components/conversationArea.tsx
+++ b/frontend/components/conversationArea.tsx
@@ -63,10 +63,16 @@ export default function ConversationArea({ onToggle }: ConversationAreaProps) {
 
           <div className="flex flex-col">
             <h3 className="font-semibold">{otherParticipantDetails?.username}</h3>
-            <div className="flex gap-1 items-center">
-              <div className="bg-green-400 size-2 rounded-full"></div>
-              <p className="">Active now</p>
-            </div>
+            {otherParticipantDetails?.isOnline ? (
+              <div className="flex gap-1 items-center">
+                <div className="bg-green-400 size-2 rounded-full"></div>
+                <p className="">Active now</p>
+              </div>
+            ) : (
+              <div className="flex gap-1 items-center">
+                <p className="">Not online</p>
+              </div>
+            )}
           </div>
         </div>
 

--- a/frontend/components/conversationArea.tsx
+++ b/frontend/components/conversationArea.tsx
@@ -13,8 +13,6 @@ import { useChatStore } from '@/store/useChatStore';
 
 import { useState, useEffect } from 'react';
 
-import { DateFormatters } from '@/types/chat';
-
 interface ConversationAreaProps {
   onToggle: (newVal?: boolean) => void; // This is a function prop
 }
@@ -25,9 +23,14 @@ export default function ConversationArea({ onToggle }: ConversationAreaProps) {
 
   const { send } = useSendMessage();
   const otherParticipantDetails = useChatStore((state) => state.otherParticipantDetails);
+
   const otherParticipantFriendshipStatus = useChatStore(
     (state) => state.otherParticipantFriendshipStatus
   );
+
+  const otherParticipantIsOnline = useChatStore((state) => state.otherParticipantIsOnline);
+
+  const otherParticipantLastOnline = useChatStore((state) => state.otherParticipantLastOnline);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -46,12 +49,12 @@ export default function ConversationArea({ onToggle }: ConversationAreaProps) {
     }
   }, [otherParticipantFriendshipStatus, onToggle]);
 
-  const formatRelativeTime = (dateString: string) => {
-    const start = new Date(dateString).getTime();
+  const formatRelativeTime = (date: Date) => {
+    const start = date.getTime();
     const now = Date.now();
     const diffInSeconds = Math.floor((now - start) / 1000);
 
-    if (diffInSeconds < 60) return 'just now';
+    if (diffInSeconds < 60) return '1m';
 
     const units = [
       { label: 'm', seconds: 60 },
@@ -67,25 +70,27 @@ export default function ConversationArea({ onToggle }: ConversationAreaProps) {
         return `${Math.floor(diffInSeconds / units[i].seconds)}${units[i].label}`;
       }
     }
-    return 'just now';
+    return '1m';
   };
 
   useEffect(() => {
     const update = () => {
       let timeStr: string = '';
 
-      if (otherParticipantDetails?.lastOnline && otherParticipantDetails?.lastOnline != undefined) {
-        timeStr = formatRelativeTime(otherParticipantDetails?.lastOnline);
+      if (otherParticipantLastOnline != null) {
+        timeStr = formatRelativeTime(otherParticipantLastOnline);
       }
       setFormattedLastOnline(timeStr || '');
     };
 
+    console.log(otherParticipantLastOnline instanceof Date);
+    console.log(otherParticipantLastOnline);
     update();
 
     const interval = setInterval(update, 60000);
 
     return () => clearInterval(interval);
-  }, [otherParticipantDetails?.lastOnline]);
+  }, [otherParticipantLastOnline]);
 
   return (
     <div className="flex-3 flex flex-col justify-start gap-2 bg-white dark:bg-stone-900 rounded-xl">
@@ -107,16 +112,14 @@ export default function ConversationArea({ onToggle }: ConversationAreaProps) {
 
           <div className="flex flex-col">
             <h3 className="font-semibold">{otherParticipantDetails?.username}</h3>
-            {otherParticipantDetails?.isOnline ? (
+            {otherParticipantIsOnline ? (
               <div className="flex gap-1 items-center">
                 <div className="bg-green-400 size-2 rounded-full"></div>
                 <p className="">Active now</p>
               </div>
             ) : (
               <div className="flex gap-1 items-center">
-                <p className="">
-                  Last active {formatRelativeTime('2025-02-21T10:33:33.266919Z')} ago
-                </p>
+                <p className="">Last active {formattedLastOnline} ago</p>
               </div>
             )}
           </div>

--- a/frontend/components/conversationTab.tsx
+++ b/frontend/components/conversationTab.tsx
@@ -10,6 +10,7 @@ import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 import { useRouter } from 'next/navigation';
+import { useAuthStore } from '@/store/useAuthStore';
 
 interface ConversationTabProps {
   conversationSnippet: ConversationSnippet;
@@ -20,6 +21,8 @@ export default function ConversationTab({ conversationSnippet }: ConversationTab
   const isActive = params.conversationId === conversationSnippet.conversationId;
 
   const router = useRouter();
+
+  const currentUserId = useAuthStore((state) => state.currentUserId);
 
   const [formattedTime, setFormattedTime] = useState('');
   const timestamp = conversationSnippet.latestMessageTime;
@@ -98,7 +101,8 @@ export default function ConversationTab({ conversationSnippet }: ConversationTab
                 : '-'}
           </p>
 
-          {conversationSnippet.hasSeenLatestMessage ? (
+          {conversationSnippet.hasSeenLatestMessage &&
+          currentUserId === conversationSnippet.latestMessageSenderId ? (
             <div className="relative w-4 h-4 shrink-0 overflow-hidden rounded-full">
               <Image
                 src={

--- a/frontend/components/conversationTab.tsx
+++ b/frontend/components/conversationTab.tsx
@@ -98,7 +98,21 @@ export default function ConversationTab({ conversationSnippet }: ConversationTab
                 : '-'}
           </p>
 
-          {conversationSnippet.latestMessage && (
+          {conversationSnippet.hasSeenLatestMessage ? (
+            <div className="relative w-4 h-4 shrink-0 overflow-hidden rounded-full">
+              <Image
+                src={
+                  conversationSnippet.otherUserAvatar
+                    ? conversationSnippet.otherUserAvatar
+                    : '/blank_picture.png'
+                }
+                alt="User avatar"
+                fill
+                sizes="96px" // Helps Next.js optimize the download size
+                className="object-cover"
+              />
+            </div>
+          ) : (
             <Icon icon="ri:check-double-fill" className="size-5 shrink-0" />
           )}
         </div>

--- a/frontend/components/messageInput.tsx
+++ b/frontend/components/messageInput.tsx
@@ -43,7 +43,6 @@ export default function MessageInput({
     });
 
     setNewMessage('');
-    await send(newMessage.trim(), tempMessageId);
 
     const error = await send(newMessage.trim(), tempMessageId);
 

--- a/frontend/components/messageInput.tsx
+++ b/frontend/components/messageInput.tsx
@@ -19,7 +19,7 @@ export default function MessageInput({
 }: MessageInputProps) {
   const [newMessage, setNewMessage] = useState('');
 
-  const { send, error: sendError } = useSendMessage();
+  const { send } = useSendMessage();
   const addSendingMessage = useChatStore((state) => state.addSendingMessage);
   const removeSendingMessage = useChatStore((state) => state.removeSendingMessage);
 
@@ -45,12 +45,16 @@ export default function MessageInput({
     setNewMessage('');
     await send(newMessage.trim(), tempMessageId);
 
-    if (sendError !== null) {
+    const error = await send(newMessage.trim(), tempMessageId);
+
+    console.log(error !== null);
+
+    if (error !== null) {
       addFailedMessage({
         tempMessageId,
         content: newMessage.trim(),
         createdAt: new Date().toISOString(),
-        status: 'sending',
+        status: 'failed',
       });
 
       removeSendingMessage(tempMessageId);

--- a/frontend/components/messageInput.tsx
+++ b/frontend/components/messageInput.tsx
@@ -1,0 +1,78 @@
+import { Button } from './ui/button';
+
+import { InputGroup, InputGroupTextarea } from '@/components/ui/input-group';
+
+import { useState } from 'react';
+
+import { useSendMessage } from '@/hooks/useChat';
+import { useChatStore } from '@/store/useChatStore';
+import { OtherParticipantDetails } from '@/types/chat';
+
+interface MessageInputProps {
+  otherParticipantFriendshipStatus: string | null;
+  otherParticipantDetails: OtherParticipantDetails | null;
+}
+
+export default function MessageInput({
+  otherParticipantFriendshipStatus,
+  otherParticipantDetails,
+}: MessageInputProps) {
+  const [newMessage, setNewMessage] = useState('');
+
+  const { send, error: sendError } = useSendMessage();
+  const addSendingMessage = useChatStore((state) => state.addSendingMessage);
+  const removeSendingMessage = useChatStore((state) => state.removeSendingMessage);
+
+  const addFailedMessage = useChatStore((state) => state.addFailedMessage);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      if (newMessage.trim() !== '') sendNewMessage();
+    }
+  };
+
+  const sendNewMessage = async () => {
+    const tempMessageId: string = crypto.randomUUID();
+
+    addSendingMessage({
+      tempMessageId,
+      content: newMessage.trim(),
+      createdAt: new Date().toISOString(),
+      status: 'sending',
+    });
+
+    setNewMessage('');
+    await send(newMessage.trim(), tempMessageId);
+
+    if (sendError !== null) {
+      addFailedMessage({
+        tempMessageId,
+        content: newMessage.trim(),
+        createdAt: new Date().toISOString(),
+        status: 'sending',
+      });
+
+      removeSendingMessage(tempMessageId);
+    }
+  };
+
+  return (
+    <div className="flex gap-2 px-2 my-2 items-end">
+      <InputGroup className="flex-1 shrink-0 min-h-0!  ">
+        <InputGroupTextarea
+          value={newMessage}
+          onChange={(e) => setNewMessage(e.target.value)}
+          onKeyDown={handleKeyDown}
+          className="min-h-4! py-2!"
+          placeholder={
+            otherParticipantFriendshipStatus !== 'accepted'
+              ? `You aren't friends with ${otherParticipantDetails?.username} anymore. This conversation is read-only.`
+              : 'Type your message...'
+          }
+        />
+      </InputGroup>
+      <Button onClick={sendNewMessage}>Send</Button>
+    </div>
+  );
+}

--- a/frontend/components/messageThread.tsx
+++ b/frontend/components/messageThread.tsx
@@ -14,6 +14,8 @@ import { themes } from '@/lib/themes';
 
 export default function MessageThread() {
   const messages = useChatStore((state) => state.messages);
+  const sendingMessages = useChatStore((state) => state.sendingMessages);
+
   const hasMorePastMessages = useChatStore((state) => state.hasMorePastMessages);
   const activeConversationId = useChatStore((state) => state.activeConversationId);
   const isInitialLoad = useChatStore((state) => state.isInitialLoad);
@@ -25,7 +27,7 @@ export default function MessageThread() {
 
   const { getPastMessages } = useGetPastMessagesFromConversation();
 
-  const { currentUserId } = useAuthStore();
+  const currentUserId = useAuthStore((state) => state.currentUserId);
 
   const topSentinelRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -87,7 +89,7 @@ export default function MessageThread() {
     if (isNearBottom) {
       scrollToBottom();
     }
-  }, [messages, activeConversationId]);
+  }, [messages, sendingMessages, activeConversationId]);
 
   useEffect(() => {
     // This useEffect activates getPastMessagesFromConversation() when sentinel is shown in viewport
@@ -180,12 +182,31 @@ export default function MessageThread() {
             key={message.messageId}
             messageId={message.messageId}
             messageType={isMe ? 'sender' : 'others'}
+            messageState="sent"
             senderId={message.senderId}
             breakMessage={isLastInCluster ? true : false}
             content={message.content}
             createdAt={message.createdAt}
             dateFormatters={dateFormatters}
             username={message.username}
+            activeConversationTheme={activeConversationTheme}
+          />
+        );
+      })}
+
+      {sendingMessages.map((tempMessage) => {
+        return (
+          <UserMessage
+            key={tempMessage.tempMessageId}
+            messageId={tempMessage.tempMessageId}
+            messageType="sender"
+            messageState="sending"
+            senderId=""
+            breakMessage={false}
+            content={tempMessage.content}
+            createdAt={tempMessage.createdAt}
+            dateFormatters={dateFormatters}
+            username=""
             activeConversationTheme={activeConversationTheme}
           />
         );

--- a/frontend/components/messageThread.tsx
+++ b/frontend/components/messageThread.tsx
@@ -1,7 +1,7 @@
 'use client';
 import UserMessage from './userMessage';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useMemo } from 'react';
 
 import { useAuthStore } from '@/store/useAuthStore';
 import { useChatStore } from '@/store/useChatStore';
@@ -15,6 +15,17 @@ import { themes } from '@/lib/themes';
 export default function MessageThread() {
   const messages = useChatStore((state) => state.messages);
   const sendingMessages = useChatStore((state) => state.sendingMessages);
+  const failedMessages = useChatStore((state) => state.failedMessages);
+
+  const pendingMessages = useMemo(() => {
+    return [...sendingMessages, ...failedMessages].sort(
+      (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+    );
+  }, [sendingMessages, failedMessages]);
+
+  useEffect(() => {
+    console.log(failedMessages);
+  }, [failedMessages]);
 
   const hasMorePastMessages = useChatStore((state) => state.hasMorePastMessages);
   const activeConversationId = useChatStore((state) => state.activeConversationId);
@@ -89,7 +100,7 @@ export default function MessageThread() {
     if (isNearBottom) {
       scrollToBottom();
     }
-  }, [messages, sendingMessages, activeConversationId]);
+  }, [messages, sendingMessages, failedMessages, activeConversationId]);
 
   useEffect(() => {
     // This useEffect activates getPastMessagesFromConversation() when sentinel is shown in viewport
@@ -194,13 +205,13 @@ export default function MessageThread() {
         );
       })}
 
-      {sendingMessages.map((tempMessage) => {
+      {pendingMessages.map((tempMessage) => {
         return (
           <UserMessage
             key={tempMessage.tempMessageId}
             messageId={tempMessage.tempMessageId}
             messageType="sender"
-            messageState="sending"
+            messageState={tempMessage.status}
             senderId=""
             breakMessage={false}
             content={tempMessage.content}

--- a/frontend/components/messageThread.tsx
+++ b/frontend/components/messageThread.tsx
@@ -34,24 +34,18 @@ export default function MessageThread() {
   const previousHeightRef = useRef(0);
 
   const dateFormatters: Record<DateFormatters, Intl.DateTimeFormat> = {
-    currentDay: new Intl.DateTimeFormat('en-US', {
+    hour: new Intl.DateTimeFormat('en-US', {
       hour: 'numeric',
       minute: '2-digit',
       hour12: true,
     }),
     currentWeek: new Intl.DateTimeFormat('en-US', {
       weekday: 'long',
-      hour: 'numeric',
-      minute: '2-digit',
-      hour12: true,
     }),
     later: new Intl.DateTimeFormat('en-US', {
       year: 'numeric',
       month: 'long',
       day: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-      hour12: true,
     }),
   };
 
@@ -184,7 +178,9 @@ export default function MessageThread() {
         return (
           <UserMessage
             key={message.messageId}
+            messageId={message.messageId}
             messageType={isMe ? 'sender' : 'others'}
+            senderId={message.senderId}
             breakMessage={isLastInCluster ? true : false}
             content={message.content}
             createdAt={message.createdAt}

--- a/frontend/components/userMessage.tsx
+++ b/frontend/components/userMessage.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState } from 'react';
 import { DateFormatters } from '@/types/chat';
 import { useChatStore } from '@/store/useChatStore';
 import { useAuthStore } from '@/store/useAuthStore';
+import { useSendMessage } from '@/hooks/useChat';
 
 interface UserMessageProps {
   messageId: string;
@@ -40,6 +41,8 @@ export default function UserMessage({
   const [formattedTime, setFormattedTime] = useState('');
   const [formattedSeenTime, setFormattedSeenTime] = useState('');
 
+  const { send } = useSendMessage();
+
   const currentUserId = useAuthStore((state) => state.currentUserId);
 
   const [dots, setDots] = useState('.');
@@ -53,6 +56,40 @@ export default function UserMessage({
   );
 
   const otherParticipantDetails = useChatStore((state) => state.otherParticipantDetails);
+
+  const addSendingMessage = useChatStore((state) => state.addSendingMessage);
+  const removeSendingMessage = useChatStore((state) => state.removeSendingMessage);
+
+  const addFailedMessage = useChatStore((state) => state.addFailedMessage);
+  const removeFailedMessage = useChatStore((state) => state.removeFailedMessage);
+
+  const resendFailedMessage = async () => {
+    removeFailedMessage(messageId);
+
+    const tempMessageId: string = crypto.randomUUID();
+
+    addSendingMessage({
+      tempMessageId,
+      content: content.trim(),
+      createdAt: new Date().toISOString(),
+      status: 'sending',
+    });
+
+    const error = await send(content.trim(), tempMessageId);
+
+    console.log(error !== null);
+
+    if (error !== null) {
+      addFailedMessage({
+        tempMessageId,
+        content: content.trim(),
+        createdAt: new Date().toISOString(),
+        status: 'failed',
+      });
+
+      removeSendingMessage(tempMessageId);
+    }
+  };
 
   useEffect(() => {
     const formatMessageTime = (dateString: string) => {
@@ -136,7 +173,7 @@ export default function UserMessage({
         </Tooltip>
       )}
 
-      <div className="flex flex-col">
+      <div className="flex flex-col items-end">
         <div className="flex flex-col">
           <Tooltip>
             <TooltipTrigger asChild>
@@ -194,8 +231,14 @@ export default function UserMessage({
           )}
 
           {messageState === 'failed' && (
-            <div className="flex justify-end pt-1">
+            <div className="flex justify-end pt-1 gap-1">
               <p className="text-xs text-red-500">Failed to send message.</p>
+              <p
+                className="text-xs text-red-500 font-bold cursor-pointer"
+                onClick={resendFailedMessage}
+              >
+                Retry?
+              </p>
             </div>
           )}
         </div>

--- a/frontend/components/userMessage.tsx
+++ b/frontend/components/userMessage.tsx
@@ -15,6 +15,7 @@ import { useAuthStore } from '@/store/useAuthStore';
 interface UserMessageProps {
   messageId: string;
   messageType: string;
+  messageState: 'sent' | 'sending' | 'failed';
   senderId: string;
   breakMessage?: boolean;
   content: string;
@@ -27,6 +28,7 @@ interface UserMessageProps {
 export default function UserMessage({
   messageId,
   messageType,
+  messageState,
   senderId,
   breakMessage = false,
   content,
@@ -39,6 +41,8 @@ export default function UserMessage({
   const [formattedSeenTime, setFormattedSeenTime] = useState('');
 
   const currentUserId = useAuthStore((state) => state.currentUserId);
+
+  const [dots, setDots] = useState('.');
 
   const otherParticipantLastReadMessageId = useChatStore(
     (state) => state.otherParticipantLastReadMessageId
@@ -95,6 +99,15 @@ export default function UserMessage({
 
     return () => clearInterval(interval);
   }, [createdAt]);
+
+  // For "animating" ellipsis when sending messages
+  useEffect(() => {
+    if (messageState !== 'sending') return;
+    const interval = setInterval(() => {
+      setDots((d) => (d.length >= 3 ? '.' : d + '.'));
+    }, 300);
+    return () => clearInterval(interval);
+  }, [messageState]);
 
   return (
     <div
@@ -168,6 +181,12 @@ export default function UserMessage({
                 </p>
               </TooltipContent>
             </Tooltip>
+          </div>
+        )}
+
+        {messageState === 'sending' && (
+          <div className="flex justify-end pt-1">
+            <p className="text-xs">Sending{dots}</p>
           </div>
         )}
       </div>

--- a/frontend/components/userMessage.tsx
+++ b/frontend/components/userMessage.tsx
@@ -137,58 +137,68 @@ export default function UserMessage({
       )}
 
       <div className="flex flex-col">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="flex flex-col gap-1">
-              <div
-                className={cn(
-                  'flex rounded-2xl items-center py-2 px-3 whitespace-pre-wrap wrap-break-word',
-                  messageType === 'sender'
-                    ? `${activeConversationTheme.sender}`
-                    : `${activeConversationTheme.receiver}`
-                )}
-              >
-                <p>{content}</p>
-              </div>
-            </div>
-          </TooltipTrigger>
-          <TooltipContent side={'left'}>
-            <p className="font-medium font-sans">{createdAt != null ? formattedTime : '-'}</p>
-          </TooltipContent>
-        </Tooltip>
-
-        {messageId === otherParticipantLastReadMessageId && currentUserId === senderId && (
-          <div className="flex justify-end pt-1">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div className="relative w-4 h-4 shrink-0 overflow-hidden rounded-full">
-                  <Image
-                    src={
-                      otherParticipantDetails?.profileImageUrl
-                        ? otherParticipantDetails.profileImageUrl
-                        : '/blank_picture.png'
-                    }
-                    alt="User avatar"
-                    fill
-                    sizes="96px" // Helps Next.js optimize the download size
-                    className="object-cover"
-                  />
+        <div className="flex flex-col">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div className="flex flex-col gap-1">
+                <div
+                  className={cn(
+                    'flex rounded-2xl items-center py-2 px-3 whitespace-pre-wrap wrap-break-word',
+                    messageType === 'sender'
+                      ? `${activeConversationTheme.sender}`
+                      : `${activeConversationTheme.receiver}`
+                  )}
+                >
+                  <p>{content}</p>
                 </div>
-              </TooltipTrigger>
-              <TooltipContent side={'left'}>
-                <p className="font-medium font-sans">
-                  {createdAt != null ? `Seen by ${username} at ${formattedSeenTime}` : '-'}
-                </p>
-              </TooltipContent>
-            </Tooltip>
-          </div>
-        )}
+              </div>
+            </TooltipTrigger>
+            <TooltipContent side={'left'}>
+              <p className="font-medium font-sans">{createdAt != null ? formattedTime : '-'}</p>
+            </TooltipContent>
+          </Tooltip>
 
-        {messageState === 'sending' && (
-          <div className="flex justify-end pt-1">
-            <p className="text-xs">Sending{dots}</p>
-          </div>
-        )}
+          {messageId === otherParticipantLastReadMessageId && currentUserId === senderId && (
+            <div className="flex justify-end pt-1">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div className="relative w-4 h-4 shrink-0 overflow-hidden rounded-full">
+                    <Image
+                      src={
+                        otherParticipantDetails?.profileImageUrl
+                          ? otherParticipantDetails.profileImageUrl
+                          : '/blank_picture.png'
+                      }
+                      alt="User avatar"
+                      fill
+                      sizes="96px" // Helps Next.js optimize the download size
+                      className="object-cover"
+                    />
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side={'left'}>
+                  <p className="font-medium font-sans">
+                    {createdAt != null ? `Seen by ${username} at ${formattedSeenTime}` : '-'}
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+            </div>
+          )}
+        </div>
+
+        <div>
+          {messageState === 'sending' && (
+            <div className="flex justify-end pt-1">
+              <p className="text-xs">Sending{dots}</p>
+            </div>
+          )}
+
+          {messageState === 'failed' && (
+            <div className="flex justify-end pt-1">
+              <p className="text-xs text-red-500">Failed to send message.</p>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/components/userMessage.tsx
+++ b/frontend/components/userMessage.tsx
@@ -9,9 +9,13 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { useEffect, useState } from 'react';
 
 import { DateFormatters } from '@/types/chat';
+import { useChatStore } from '@/store/useChatStore';
+import { useAuthStore } from '@/store/useAuthStore';
 
 interface UserMessageProps {
+  messageId: string;
   messageType: string;
+  senderId: string;
   breakMessage?: boolean;
   content: string;
   createdAt: string;
@@ -21,7 +25,9 @@ interface UserMessageProps {
 }
 
 export default function UserMessage({
+  messageId,
   messageType,
+  senderId,
   breakMessage = false,
   content,
   createdAt,
@@ -30,6 +36,19 @@ export default function UserMessage({
   activeConversationTheme,
 }: UserMessageProps) {
   const [formattedTime, setFormattedTime] = useState('');
+  const [formattedSeenTime, setFormattedSeenTime] = useState('');
+
+  const currentUserId = useAuthStore((state) => state.currentUserId);
+
+  const otherParticipantLastReadMessageId = useChatStore(
+    (state) => state.otherParticipantLastReadMessageId
+  );
+
+  const otherParticipantLastReadMessageAt = useChatStore(
+    (state) => state.otherParticipantLastReadMessageAt
+  );
+
+  const otherParticipantDetails = useChatStore((state) => state.otherParticipantDetails);
 
   useEffect(() => {
     const formatMessageTime = (dateString: string) => {
@@ -38,15 +57,36 @@ export default function UserMessage({
 
       const diffInSeconds = Math.floor((now - start) / 1000);
 
-      if (diffInSeconds >= 604800) return dateFormatters.later.format(start);
-      else if (diffInSeconds >= 86400) return dateFormatters.currentWeek.format(start);
+      if (diffInSeconds >= 604800)
+        return `${dateFormatters.later.format(start)}, ${dateFormatters.hour.format(start)}`;
+      else if (diffInSeconds >= 86400)
+        return `${dateFormatters.currentWeek.format(start)}, ${dateFormatters.hour.format(start)}`;
 
-      return dateFormatters.currentDay.format(start);
+      return `${dateFormatters.hour.format(start)}`;
+    };
+
+    const formatSeenTime = (date: Date | null) => {
+      if (date == null) return '';
+
+      const start = date.getTime();
+      const now = Date.now();
+
+      const diffInSeconds = Math.floor((now - start) / 1000);
+
+      if (diffInSeconds >= 604800)
+        return `${dateFormatters.later.format(start)}, ${dateFormatters.hour.format(start)}`;
+      else if (diffInSeconds >= 86400)
+        return `${dateFormatters.currentWeek.format(start)}, ${dateFormatters.hour.format(start)}`;
+
+      return `${dateFormatters.hour.format(start)}`;
     };
 
     const update = () => {
       const timeStr = formatMessageTime(createdAt);
       setFormattedTime(timeStr || '');
+
+      const timeSeenStr = formatSeenTime(otherParticipantLastReadMessageAt);
+      setFormattedSeenTime(timeSeenStr || '');
     };
 
     update();
@@ -83,23 +123,54 @@ export default function UserMessage({
         </Tooltip>
       )}
 
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <div
-            className={cn(
-              'flex rounded-2xl items-center py-2 px-3 whitespace-pre-wrap wrap-break-word',
-              messageType === 'sender'
-                ? `${activeConversationTheme.sender}`
-                : `${activeConversationTheme.receiver}`
-            )}
-          >
-            <p>{content}</p>
+      <div className="flex flex-col">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div className="flex flex-col gap-1">
+              <div
+                className={cn(
+                  'flex rounded-2xl items-center py-2 px-3 whitespace-pre-wrap wrap-break-word',
+                  messageType === 'sender'
+                    ? `${activeConversationTheme.sender}`
+                    : `${activeConversationTheme.receiver}`
+                )}
+              >
+                <p>{content}</p>
+              </div>
+            </div>
+          </TooltipTrigger>
+          <TooltipContent side={'left'}>
+            <p className="font-medium font-sans">{createdAt != null ? formattedTime : '-'}</p>
+          </TooltipContent>
+        </Tooltip>
+
+        {messageId === otherParticipantLastReadMessageId && currentUserId === senderId && (
+          <div className="flex justify-end pt-1">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div className="relative w-4 h-4 shrink-0 overflow-hidden rounded-full">
+                  <Image
+                    src={
+                      otherParticipantDetails?.profileImageUrl
+                        ? otherParticipantDetails.profileImageUrl
+                        : '/blank_picture.png'
+                    }
+                    alt="User avatar"
+                    fill
+                    sizes="96px" // Helps Next.js optimize the download size
+                    className="object-cover"
+                  />
+                </div>
+              </TooltipTrigger>
+              <TooltipContent side={'left'}>
+                <p className="font-medium font-sans">
+                  {createdAt != null ? `Seen by ${username} at ${formattedSeenTime}` : '-'}
+                </p>
+              </TooltipContent>
+            </Tooltip>
           </div>
-        </TooltipTrigger>
-        <TooltipContent side={'left'}>
-          <p className="font-medium font-sans">{createdAt != null ? formattedTime : '-'}</p>
-        </TooltipContent>
-      </Tooltip>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/hooks/useChat.ts
+++ b/frontend/hooks/useChat.ts
@@ -30,12 +30,11 @@ export function useSendMessage() {
     setError(null);
     try {
       await sendMessage(content, tempMessageId, activeConversationId);
+      return null;
     } catch (err: unknown) {
-      if (err instanceof Error) {
-        setError(err.message);
-      } else {
-        setError('An unexpected error occurred');
-      }
+      const message = err instanceof Error ? err.message : 'An unexpected error occurred';
+      setError(message);
+      return message;
     } finally {
       setLoading(false);
     }

--- a/frontend/hooks/useChat.ts
+++ b/frontend/hooks/useChat.ts
@@ -305,13 +305,19 @@ export const useInitializeWebsocket = () => {
 
     setSocket(ws);
 
-    return () => {
-      console.log('run onunmount');
+    const interval = setInterval(() => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: 'PING' }));
+      }
+    }, 30000);
 
+    return () => {
       if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
         console.log('Cleaning up connection for:', currentUserId);
         ws.close();
       }
+
+      clearInterval(interval);
     };
   }, [
     currentUserId,

--- a/frontend/hooks/useChat.ts
+++ b/frontend/hooks/useChat.ts
@@ -283,6 +283,14 @@ export const useInitializeWebsocket = () => {
     (state) => state.setOtherParticipantLastOnline
   );
 
+  const setOtherParticipantLastReadMessageId = useChatStore(
+    (state) => state.setOtherParticipantLastReadMessageId
+  );
+
+  const setOtherParticipantLastReadMessageAt = useChatStore(
+    (state) => state.setOtherParticipantLastReadMessageAt
+  );
+
   const currentUserId = useAuthStore((state) => state.currentUserId);
 
   const upsertSnippet = useSidebarStore((state) => state.upsertSnippet);
@@ -348,7 +356,14 @@ export const useInitializeWebsocket = () => {
           setOtherParticipantLastOnline(null);
         }
       } else if (eventData.type === 'MESSAGE_SEEN') {
-        console.log(eventData);
+        setOtherParticipantLastReadMessageId(eventData.data.lastReadMessageId);
+
+        if (eventData.data.lastReadMessageAt) {
+          const date = new Date(eventData.data.lastReadMessageAt);
+          setOtherParticipantLastReadMessageAt(date);
+        } else {
+          setOtherParticipantLastReadMessageAt(null);
+        }
       }
     };
 

--- a/frontend/hooks/useChat.ts
+++ b/frontend/hooks/useChat.ts
@@ -25,11 +25,11 @@ export function useSendMessage() {
 
   const activeConversationId = useChatStore((state) => state.activeConversationId);
 
-  const send = async (content: string) => {
+  const send = async (content: string, tempMessageId: string) => {
     setLoading(true);
     setError(null);
     try {
-      await sendMessage(content, activeConversationId);
+      await sendMessage(content, tempMessageId, activeConversationId);
     } catch (err: unknown) {
       if (err instanceof Error) {
         setError(err.message);
@@ -291,6 +291,8 @@ export const useInitializeWebsocket = () => {
     (state) => state.setOtherParticipantLastReadMessageAt
   );
 
+  const removeSendingMessage = useChatStore((state) => state.removeSendingMessage);
+
   const currentUserId = useAuthStore((state) => state.currentUserId);
 
   const upsertSnippet = useSidebarStore((state) => state.upsertSnippet);
@@ -319,7 +321,11 @@ export const useInitializeWebsocket = () => {
         if (eventData.data.conversationId === latestActiveConversationId) {
           addMessage(eventData.data);
 
-          if (latestActiveConversationId) markAsRead(latestActiveConversationId);
+          if (eventData.data.senderId === currentUserId) {
+            removeSendingMessage(eventData.data.tempMessageId);
+          } else if (latestActiveConversationId) {
+            markAsRead(latestActiveConversationId);
+          }
         }
         upsertSnippet(eventData.data);
       } else if (eventData.type === 'UPDATE_CONVERSATION') {
@@ -406,5 +412,7 @@ export const useInitializeWebsocket = () => {
     setOtherParticipantIsOnline,
     setOtherParticipantLastOnline,
     updateHasSeenLatestMessage,
+    setOtherParticipantLastReadMessageAt,
+    setOtherParticipantLastReadMessageId,
   ]);
 };

--- a/frontend/hooks/useChat.ts
+++ b/frontend/hooks/useChat.ts
@@ -295,6 +295,8 @@ export const useInitializeWebsocket = () => {
 
   const upsertSnippet = useSidebarStore((state) => state.upsertSnippet);
 
+  const updateHasSeenLatestMessage = useSidebarStore((state) => state.updateHasSeenLatestMessage);
+
   const { markAsRead } = useMarkConversationAsRead();
 
   useEffect(() => {
@@ -356,6 +358,12 @@ export const useInitializeWebsocket = () => {
           setOtherParticipantLastOnline(null);
         }
       } else if (eventData.type === 'MESSAGE_SEEN') {
+        updateHasSeenLatestMessage(
+          eventData.data.conversationId,
+          eventData.data.hasSeenLatestMessage,
+          eventData.data.latestMessageSenderId
+        );
+
         setOtherParticipantLastReadMessageId(eventData.data.lastReadMessageId);
 
         if (eventData.data.lastReadMessageAt) {
@@ -397,5 +405,6 @@ export const useInitializeWebsocket = () => {
     setConversationThemeChangedBy,
     setOtherParticipantIsOnline,
     setOtherParticipantLastOnline,
+    updateHasSeenLatestMessage,
   ]);
 };

--- a/frontend/hooks/useChat.ts
+++ b/frontend/hooks/useChat.ts
@@ -91,7 +91,15 @@ export function useGetOtherParticipantFromConversation() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const { setIsGettingOtherParticipant, setOtherParticipantDetails } = useChatStore();
+  const setIsGettingOtherParticipant = useChatStore((state) => state.setIsGettingOtherParticipant);
+
+  const setOtherParticipantDetails = useChatStore((state) => state.setOtherParticipantDetails);
+
+  const setOtherParticipantIsOnline = useChatStore((state) => state.setOtherParticipantIsOnline);
+
+  const setOtherParticipantLastOnline = useChatStore(
+    (state) => state.setOtherParticipantLastOnline
+  );
 
   const getOtherParticipant = async (conversationId: string) => {
     // put this here??
@@ -104,9 +112,17 @@ export function useGetOtherParticipantFromConversation() {
       if (conversationId) {
         console.log(`here ${conversationId}`);
         const data = await getOtherParticipantFromConversation(conversationId);
-        console.log(data);
 
         setOtherParticipantDetails(data);
+
+        setOtherParticipantIsOnline(data.isOnline);
+
+        if (data.lastOnline) {
+          const date = new Date(data.lastOnline);
+          setOtherParticipantLastOnline(date);
+        } else {
+          setOtherParticipantLastOnline(null);
+        }
       } else {
         throw Error('No conversation ID');
       }
@@ -249,6 +265,12 @@ export const useInitializeWebsocket = () => {
     (state) => state.setConversationThemeChangedAt
   );
 
+  const setOtherParticipantIsOnline = useChatStore((state) => state.setOtherParticipantIsOnline);
+
+  const setOtherParticipantLastOnline = useChatStore(
+    (state) => state.setOtherParticipantLastOnline
+  );
+
   const currentUserId = useAuthStore((state) => state.currentUserId);
 
   const upsertSnippet = useSidebarStore((state) => state.upsertSnippet);
@@ -298,6 +320,17 @@ export const useInitializeWebsocket = () => {
         toast.success(
           `The theme for this conversation has recently been set to ${selectedTheme?.label} by ${eventData.data.changedBy}.`
         );
+      } else if (eventData.type === 'USER_ONLINE') {
+        setOtherParticipantIsOnline(eventData.data.isOnline);
+      } else if (eventData.type === 'USER_OFFLINE') {
+        setOtherParticipantIsOnline(eventData.data.isOnline);
+
+        if (eventData.data.lastOnline) {
+          const date = new Date(eventData.data.lastOnline);
+          setOtherParticipantLastOnline(date);
+        } else {
+          setOtherParticipantLastOnline(null);
+        }
       }
     };
 

--- a/frontend/hooks/useChat.ts
+++ b/frontend/hooks/useChat.ts
@@ -14,6 +14,7 @@ import {
   createDirectMessage,
   updateConversationTheme,
   getConversationTheme,
+  markConversationAsRead,
 } from '@/lib/api/messages';
 
 const fastapiWebsocketUrl = process.env.NEXT_PUBLIC_FASTAPI_WEBSOCKET_URL;
@@ -22,7 +23,7 @@ export function useSendMessage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const { activeConversationId } = useChatStore();
+  const activeConversationId = useChatStore((state) => state.activeConversationId);
 
   const send = async (content: string) => {
     setLoading(true);
@@ -95,12 +96,6 @@ export function useGetOtherParticipantFromConversation() {
 
   const setOtherParticipantDetails = useChatStore((state) => state.setOtherParticipantDetails);
 
-  const setOtherParticipantIsOnline = useChatStore((state) => state.setOtherParticipantIsOnline);
-
-  const setOtherParticipantLastOnline = useChatStore(
-    (state) => state.setOtherParticipantLastOnline
-  );
-
   const getOtherParticipant = async (conversationId: string) => {
     // put this here??
     setIsGettingOtherParticipant(true);
@@ -113,16 +108,9 @@ export function useGetOtherParticipantFromConversation() {
         console.log(`here ${conversationId}`);
         const data = await getOtherParticipantFromConversation(conversationId);
 
+        console.log(data);
+
         setOtherParticipantDetails(data);
-
-        setOtherParticipantIsOnline(data.isOnline);
-
-        if (data.lastOnline) {
-          const date = new Date(data.lastOnline);
-          setOtherParticipantLastOnline(date);
-        } else {
-          setOtherParticipantLastOnline(null);
-        }
       } else {
         throw Error('No conversation ID');
       }
@@ -244,6 +232,30 @@ export function useUpdateConversationTheme() {
   return { changeConversationTheme, loading, error };
 }
 
+export function useMarkConversationAsRead() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const markAsRead = async (conversationId: string) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await markConversationAsRead(conversationId);
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError('An unexpected error occurred');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { markAsRead, loading, error };
+}
+
 export const useInitializeWebsocket = () => {
   const clearChat = useChatStore((state) => state.clearChat);
 
@@ -275,6 +287,8 @@ export const useInitializeWebsocket = () => {
 
   const upsertSnippet = useSidebarStore((state) => state.upsertSnippet);
 
+  const { markAsRead } = useMarkConversationAsRead();
+
   useEffect(() => {
     if (!currentUserId) return;
 
@@ -294,6 +308,8 @@ export const useInitializeWebsocket = () => {
       if (eventData.type === 'NEW_MESSAGE') {
         if (eventData.data.conversationId === latestActiveConversationId) {
           addMessage(eventData.data);
+
+          if (latestActiveConversationId) markAsRead(latestActiveConversationId);
         }
         upsertSnippet(eventData.data);
       } else if (eventData.type === 'UPDATE_CONVERSATION') {
@@ -331,6 +347,8 @@ export const useInitializeWebsocket = () => {
         } else {
           setOtherParticipantLastOnline(null);
         }
+      } else if (eventData.type === 'MESSAGE_SEEN') {
+        console.log(eventData);
       }
     };
 
@@ -362,5 +380,7 @@ export const useInitializeWebsocket = () => {
     setConversationTheme,
     setConversationThemeChangedAt,
     setConversationThemeChangedBy,
+    setOtherParticipantIsOnline,
+    setOtherParticipantLastOnline,
   ]);
 };

--- a/frontend/hooks/useConversationTabs.ts
+++ b/frontend/hooks/useConversationTabs.ts
@@ -6,7 +6,14 @@ import { getUserConversationsList } from '@/lib/api/messages';
 import { useSidebarStore } from '@/store/useSidebarStore';
 
 export function useConversationTabs() {
-  const { conversationSnippets, isLoading, setSnippets, setLoading } = useSidebarStore();
+  const conversationSnippets = useSidebarStore((state) => state.conversationSnippets);
+
+  const isLoading = useSidebarStore((state) => state.isLoading);
+
+  const setSnippets = useSidebarStore((state) => state.setSnippets);
+
+  const setLoading = useSidebarStore((state) => state.setLoading);
+
   const [error, setError] = useState<string | null>(null);
 
   const getConversations = async () => {

--- a/frontend/lib/api/messages.ts
+++ b/frontend/lib/api/messages.ts
@@ -14,6 +14,8 @@ export async function getUserConversationsList() {
 }
 
 export async function sendMessage(content: string, activeConversationId: string | null) {
+  console.log(activeConversationId);
+
   const res = await fetch(`${fastapiServerUrl}/api/messages/send`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -90,5 +92,17 @@ export async function updateConversationTheme(conversationId: string, theme: str
   });
 
   if (!res.ok) throw new Error('Something went wrong when updating the conversation theme.');
+  return res.json();
+}
+
+export async function markConversationAsRead(conversationId: string) {
+  const res = await fetch(`${fastapiServerUrl}/api/messages/mark-as-read`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ conversationId }),
+    credentials: 'include',
+  });
+
+  if (!res.ok) throw new Error('Something went wrong when creating marking conversation as read.');
   return res.json();
 }

--- a/frontend/lib/api/messages.ts
+++ b/frontend/lib/api/messages.ts
@@ -13,13 +13,17 @@ export async function getUserConversationsList() {
   return res.json();
 }
 
-export async function sendMessage(content: string, activeConversationId: string | null) {
+export async function sendMessage(
+  content: string,
+  tempMessageId: string,
+  activeConversationId: string | null
+) {
   console.log(activeConversationId);
 
   const res = await fetch(`${fastapiServerUrl}/api/messages/send`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ content, conversation_id: activeConversationId }),
+    body: JSON.stringify({ content, tempMessageId, conversationId: activeConversationId }),
     credentials: 'include',
   });
 

--- a/frontend/store/useChatStore.ts
+++ b/frontend/store/useChatStore.ts
@@ -16,6 +16,8 @@ interface ChatState {
   otherParticipantFriendshipStatus: string | null;
   otherParticipantIsOnline: boolean;
   otherParticipantLastOnline: Date | null;
+  otherParticipantLastReadMessageId: string | null;
+  otherParticipantLastReadMessageAt: Date | null;
 
   conversationTheme: string;
   conversationThemeChangedAt: Date | null;
@@ -62,6 +64,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
   otherParticipantIsOnline: false,
   otherParticipantLastOnline: null,
+  otherParticipantLastReadMessageId: null,
+  otherParticipantLastReadMessageAt: null,
 
   addMessage: (newMessage) =>
     set((state) => {
@@ -98,12 +102,47 @@ export const useChatStore = create<ChatState>((set, get) => ({
   },
 
   setOtherParticipantDetails: (newParticipantDetails) => {
+    console.log(newParticipantDetails);
+
     set({
       otherParticipantDetails: newParticipantDetails,
     });
+
     set({
       otherParticipantFriendshipStatus: newParticipantDetails?.friendshipStatus,
     });
+
+    set({
+      otherParticipantIsOnline: newParticipantDetails?.isOnline,
+    });
+
+    if (newParticipantDetails?.lastOnline) {
+      const date = new Date(newParticipantDetails.lastOnline);
+
+      set({
+        otherParticipantLastOnline: date,
+      });
+    } else {
+      set({
+        otherParticipantLastOnline: null,
+      });
+    }
+
+    set({
+      otherParticipantLastReadMessageId: newParticipantDetails?.lastReadMessageId,
+    });
+
+    if (newParticipantDetails?.lastReadMessageAt) {
+      const date = new Date(newParticipantDetails.lastReadMessageAt);
+
+      set({
+        otherParticipantLastReadMessageAt: date,
+      });
+    } else {
+      set({
+        otherParticipantLastReadMessageAt: null,
+      });
+    }
   },
 
   setIsInitialLoad: (newVal: boolean) => set({ isInitialLoad: newVal }),

--- a/frontend/store/useChatStore.ts
+++ b/frontend/store/useChatStore.ts
@@ -207,9 +207,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
   setSocket: (socket) => set({ socket }),
 
-  clearChat: () => set({ messages: [], socket: null, activeConversationId: null }),
+  clearChat: () => set({ messages: [], socket: null }),
 
-  resetConversation: (conversationId?: string) =>
+  resetConversation: (conversationId?: string) => {
     set({
       activeConversationId: conversationId ?? null,
       messages: [],
@@ -217,7 +217,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
       isInitialLoad: true,
       isGettingOtherParticipant: true,
       otherParticipantFriendshipStatus: null,
-    }),
+    });
+  },
 
   setOtherParticipantIsOnline: (newVal: boolean) => set({ otherParticipantIsOnline: newVal }),
 

--- a/frontend/store/useChatStore.ts
+++ b/frontend/store/useChatStore.ts
@@ -99,6 +99,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
   addFailedMessage: (newMessage) =>
     set((state) => {
+      console.log(state.failedMessages);
+
       return { failedMessages: [...state.failedMessages, newMessage] };
     }),
 

--- a/frontend/store/useChatStore.ts
+++ b/frontend/store/useChatStore.ts
@@ -1,8 +1,11 @@
 import { create } from 'zustand';
-import { Message, OtherParticipantDetails } from '@/types/chat';
+import { Message, OtherParticipantDetails, TempMessage } from '@/types/chat';
 
 interface ChatState {
   messages: Message[];
+  sendingMessages: TempMessage[];
+  failedMessages: TempMessage[];
+
   otherParticipantDetails: OtherParticipantDetails | null;
   socket: WebSocket | null;
   activeConversationId: string | null;
@@ -24,9 +27,15 @@ interface ChatState {
   conversationThemeChangedBy: string | null;
 
   // Actions
-  addMessage: (msg: Message) => void;
+  addMessage: (newMessage: Message) => void;
+  addSendingMessage: (newMessage: TempMessage) => void;
+  addFailedMessage: (newMessage: TempMessage) => void;
+
+  removeSendingMessage: (tempMessageId: string) => void;
+  removeFailedMessage: (tempMessageId: string) => void;
+
   prependPastMessages: (pastMessages: Message[]) => void;
-  setMessages: (msgs: Message[]) => void;
+  setMessages: (newMessages: Message[]) => void;
   setActiveConversationId: (conversationId: string | null) => void;
   setOtherParticipantDetails: (newParticipantDetails: OtherParticipantDetails | null) => void;
   setIsInitialLoad: (newVal: boolean) => void;
@@ -52,6 +61,9 @@ interface ChatState {
 
 export const useChatStore = create<ChatState>((set, get) => ({
   messages: [],
+  sendingMessages: [],
+  failedMessages: [],
+
   otherParticipantDetails: null,
   socket: null,
   activeConversationId: null,
@@ -80,6 +92,30 @@ export const useChatStore = create<ChatState>((set, get) => ({
       return { messages: [...state.messages, newMessage] };
     }),
 
+  addSendingMessage: (newMessage) =>
+    set((state) => {
+      return { sendingMessages: [...state.sendingMessages, newMessage] };
+    }),
+
+  addFailedMessage: (newMessage) =>
+    set((state) => {
+      return { failedMessages: [...state.failedMessages, newMessage] };
+    }),
+
+  removeSendingMessage: (tempMessageId: string) =>
+    set((state) => {
+      return {
+        sendingMessages: state.sendingMessages.filter((msg) => msg.tempMessageId !== tempMessageId),
+      };
+    }),
+
+  removeFailedMessage: (tempMessageId: string) =>
+    set((state) => {
+      return {
+        failedMessages: state.failedMessages.filter((msg) => msg.tempMessageId !== tempMessageId),
+      };
+    }),
+
   prependPastMessages: (pastMessages: Message[]) =>
     set((state) => {
       // Checks if messageIds already exists in messages array
@@ -95,7 +131,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       };
     }),
 
-  setMessages: (msgs) => set({ messages: msgs }),
+  setMessages: (newMessages: Message[]) => set({ messages: newMessages }),
 
   setActiveConversationId: (conversationId) => {
     if (get().activeConversationId === conversationId) return;

--- a/frontend/store/useChatStore.ts
+++ b/frontend/store/useChatStore.ts
@@ -7,11 +7,16 @@ interface ChatState {
   socket: WebSocket | null;
   activeConversationId: string | null;
   hasMorePastMessages: boolean;
+
   isInitialLoad: boolean;
   isGetting: boolean;
   isSending: boolean;
+
   isGettingOtherParticipant: boolean;
   otherParticipantFriendshipStatus: string | null;
+  otherParticipantIsOnline: boolean;
+  otherParticipantLastOnline: Date | null;
+
   conversationTheme: string;
   conversationThemeChangedAt: Date | null;
   conversationThemeChangedBy: string | null;
@@ -30,6 +35,9 @@ interface ChatState {
   setConversationTheme: (newVal: string) => void;
   setConversationThemeChangedAt: (newVal: Date | null) => void;
   setConversationThemeChangedBy: (newVal: string | null) => void;
+
+  setOtherParticipantIsOnline: (newVal: boolean) => void;
+  setOtherParticipantLastOnline: (newVal: Date | null) => void;
 
   setSocket: (socket: WebSocket | null) => void;
   clearChat: () => void;
@@ -51,6 +59,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
   conversationTheme: 'default',
   conversationThemeChangedAt: null,
   conversationThemeChangedBy: null,
+
+  otherParticipantIsOnline: false,
+  otherParticipantLastOnline: null,
 
   addMessage: (newMessage) =>
     set((state) => {
@@ -127,4 +138,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
       isGettingOtherParticipant: true,
       otherParticipantFriendshipStatus: null,
     }),
+
+  setOtherParticipantIsOnline: (newVal: boolean) => set({ otherParticipantIsOnline: newVal }),
+
+  setOtherParticipantLastOnline: (newVal: Date | null) =>
+    set({ otherParticipantLastOnline: newVal }),
 }));

--- a/frontend/store/useChatStore.ts
+++ b/frontend/store/useChatStore.ts
@@ -41,6 +41,9 @@ interface ChatState {
   setOtherParticipantIsOnline: (newVal: boolean) => void;
   setOtherParticipantLastOnline: (newVal: Date | null) => void;
 
+  setOtherParticipantLastReadMessageId: (newVal: string | null) => void;
+  setOtherParticipantLastReadMessageAt: (newVal: Date | null) => void;
+
   setSocket: (socket: WebSocket | null) => void;
   clearChat: () => void;
 
@@ -182,4 +185,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
   setOtherParticipantLastOnline: (newVal: Date | null) =>
     set({ otherParticipantLastOnline: newVal }),
+
+  setOtherParticipantLastReadMessageId: (newVal: string | null) =>
+    set({ otherParticipantLastReadMessageId: newVal }),
+
+  setOtherParticipantLastReadMessageAt: (newVal: Date | null) =>
+    set({ otherParticipantLastReadMessageAt: newVal }),
 }));

--- a/frontend/store/useSidebarStore.ts
+++ b/frontend/store/useSidebarStore.ts
@@ -8,6 +8,12 @@ interface SidebarState {
   // Actions
   setSnippets: (snippets: ConversationSnippet[]) => void;
   upsertSnippet: (message: Message) => void;
+
+  updateHasSeenLatestMessage: (
+    conversationId: string,
+    newHasSeenLatestMessage: boolean,
+    latestMessageSenderId: string
+  ) => void;
   setLoading: (value: boolean) => void;
 }
 
@@ -31,6 +37,26 @@ export const useSidebarStore = create<SidebarState>((set) => ({
         movedItem.latestMessageTime = message.createdAt;
         updatedSnippets.unshift(movedItem);
       }
+
+      return { conversationSnippets: updatedSnippets };
+    }),
+
+  updateHasSeenLatestMessage: (
+    conversationId: string,
+    newHasSeenLatestMessage: boolean,
+    latestMessageSenderId: string
+  ) =>
+    set((state) => {
+      const index = state.conversationSnippets.findIndex(
+        (s) => s.conversationId === conversationId
+      );
+      const updatedSnippets = [...state.conversationSnippets];
+
+      const conversationSnippet = updatedSnippets[index];
+      conversationSnippet['hasSeenLatestMessage'] = newHasSeenLatestMessage;
+      conversationSnippet['latestMessageSenderId'] = latestMessageSenderId;
+
+      updatedSnippets[index] = conversationSnippet;
 
       return { conversationSnippets: updatedSnippets };
     }),

--- a/frontend/types/chat.ts
+++ b/frontend/types/chat.ts
@@ -22,6 +22,7 @@ export interface OtherParticipantDetails {
   profileImageUrl: string;
   friendshipStatus: string;
   isOnline: boolean;
+  lastOnline: string | null;
 }
 
 export type DateFormatters = 'currentDay' | 'currentWeek' | 'later';

--- a/frontend/types/chat.ts
+++ b/frontend/types/chat.ts
@@ -8,6 +8,13 @@ export interface Message {
   status: string;
 }
 
+export interface TempMessage {
+  tempMessageId: string;
+  content: string;
+  createdAt: string;
+  status: 'sending' | 'failed';
+}
+
 export interface ConversationSnippet {
   conversationId: string;
   otherUserName: string;

--- a/frontend/types/chat.ts
+++ b/frontend/types/chat.ts
@@ -14,7 +14,8 @@ export interface ConversationSnippet {
   otherUserAvatar: string;
   latestMessage: string;
   latestMessageTime: string;
-  hasSeenLatestMessage: string;
+  hasSeenLatestMessage: boolean;
+  latestMessageSenderId: string;
 }
 
 export interface OtherParticipantDetails {

--- a/frontend/types/chat.ts
+++ b/frontend/types/chat.ts
@@ -23,6 +23,8 @@ export interface OtherParticipantDetails {
   friendshipStatus: string;
   isOnline: boolean;
   lastOnline: string | null;
+  lastReadMessageId: string;
+  lastReadMessageAt: string | null;
 }
 
-export type DateFormatters = 'currentDay' | 'currentWeek' | 'later';
+export type DateFormatters = 'hour' | 'currentWeek' | 'later';

--- a/frontend/types/chat.ts
+++ b/frontend/types/chat.ts
@@ -21,6 +21,7 @@ export interface OtherParticipantDetails {
   username: string;
   profileImageUrl: string;
   friendshipStatus: string;
+  isOnline: boolean;
 }
 
 export type DateFormatters = 'currentDay' | 'currentWeek' | 'later';

--- a/frontend/types/chat.ts
+++ b/frontend/types/chat.ts
@@ -14,6 +14,7 @@ export interface ConversationSnippet {
   otherUserAvatar: string;
   latestMessage: string;
   latestMessageTime: string;
+  hasSeenLatestMessage: string;
 }
 
 export interface OtherParticipantDetails {


### PR DESCRIPTION
### What's changed

- **Real-time online status** — users now see live active/offline indicators powered by WebSocket events
- **Last seen tracking** — displays relative time since a user was last active, updating every minute
- **Optimistic messaging** — messages appear instantly with a `Sending...` indicator while in-flight, and show a `Retry?` prompt on error

### Notes

- Fixed `activeConversationId` being wiped on hard refresh due to `clearChat` incorrectly resetting it